### PR TITLE
Added testing plugins to pluginManagement

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,8 +38,10 @@
     <aerius-tools.version>1.2.0</aerius-tools.version>
     <dependency-check-maven.version>8.2.1</dependency-check-maven.version>
     <jackson-databind-nullable.version>0.2.6</jackson-databind-nullable.version>
+    <jacoco-maven-plugin.version>0.8.10</jacoco-maven-plugin.version>
     <license-maven-plugin.version>4.2</license-maven-plugin.version>
     <maven-enforcer-plugin.version>3.3.0</maven-enforcer-plugin.version>
+    <maven-surefire-plugin.version>3.0.0</maven-surefire-plugin.version>
     <openapi-generator-maven-plugin.version>6.5.0</openapi-generator-maven-plugin.version>
     <spring-boot.version>3.0.6</spring-boot.version>
     <swagger-parser.version>2.1.13</swagger-parser.version>
@@ -131,6 +133,46 @@
           <groupId>org.springframework.boot</groupId>
           <artifactId>spring-boot-maven-plugin</artifactId>
           <version>${spring-boot.version}</version>
+          <executions>
+            <execution>
+              <id>repackage</id>
+              <goals>
+                <goal>repackage</goal>
+              </goals>
+            </execution>
+          </executions>
+        </plugin>
+
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-surefire-plugin</artifactId>
+          <version>${maven-surefire-plugin.version}</version>
+        </plugin>
+
+        <plugin>
+          <groupId>org.jacoco</groupId>
+          <artifactId>jacoco-maven-plugin</artifactId>
+          <version>${jacoco-maven-plugin.version}</version>
+          <executions>
+            <execution>
+              <id>prepare-agent</id>
+              <goals>
+                <goal>prepare-agent</goal>
+              </goals>
+            </execution>
+            <execution>
+              <id>report</id>
+              <phase>prepare-package</phase>
+              <goals>
+                <goal>report</goal>
+              </goals>
+              <configuration>
+                <formats>
+                  <format>XML</format>
+                </formats>
+              </configuration>
+            </execution>
+          </executions>
         </plugin>
 
         <plugin>


### PR DESCRIPTION
Added surefire-plugin specific version (the default is 2.12.4, which doesn't pick up the jupiter tests), and specified jacoco-maven-plugin with a common configuration to pluginManagement. 
It's up to the projects using this parent pom to actually use these plugins when applicable (though surefire will be used by default anyway).

Also added common configuration for the spring-boot-mavn-plugin, to save some more repetition.