### PR TITLE
Added plugin configuration to help with manifest info

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,11 +36,13 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
     <aerius-tools.version>1.2.0</aerius-tools.version>
+    <buildnumber-maven-plugin.version>3.0.0</buildnumber-maven-plugin.version>
     <dependency-check-maven.version>8.2.1</dependency-check-maven.version>
     <jackson-databind-nullable.version>0.2.6</jackson-databind-nullable.version>
     <jacoco-maven-plugin.version>0.8.10</jacoco-maven-plugin.version>
     <license-maven-plugin.version>4.2</license-maven-plugin.version>
     <maven-enforcer-plugin.version>3.3.0</maven-enforcer-plugin.version>
+    <maven-jar-plugin.version>3.3.0</maven-jar-plugin.version>
     <maven-surefire-plugin.version>3.0.0</maven-surefire-plugin.version>
     <openapi-generator-maven-plugin.version>6.5.0</openapi-generator-maven-plugin.version>
     <spring-boot.version>3.0.6</spring-boot.version>
@@ -127,6 +129,54 @@
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-enforcer-plugin</artifactId>
           <version>${maven-enforcer-plugin.version}</version>
+        </plugin>
+
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-jar-plugin</artifactId>
+          <version>${maven-jar-plugin.version}</version>
+          <configuration>
+            <archive>
+              <manifest>
+                <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
+              </manifest>
+            </archive>
+          </configuration>
+        </plugin>
+
+        <plugin>
+          <groupId>org.codehaus.mojo</groupId>
+          <artifactId>buildnumber-maven-plugin</artifactId>
+          <version>${buildnumber-maven-plugin.version}</version>
+          <executions>
+            <execution>
+              <id>generate-buildDateTime</id>
+              <phase>validate</phase>
+              <goals>
+                <goal>create</goal>
+              </goals>
+              <configuration>
+                <format>{0,date,yyyyMMdd}</format>
+                <items>
+                  <item>timestamp</item>
+                </items>
+                <buildNumberPropertyName>buildDateTime</buildNumberPropertyName>
+              </configuration>
+            </execution>
+            <execution>
+              <id>generate-buildRevision</id>
+              <phase>validate</phase>
+              <goals>
+                <goal>create</goal>
+              </goals>
+              <configuration>
+                <doCheck>false</doCheck>
+                <doUpdate>false</doUpdate>
+                <shortRevisionLength>10</shortRevisionLength>
+                <buildNumberPropertyName>buildRevision</buildNumberPropertyName>
+              </configuration>
+            </execution>
+          </executions>
         </plugin>
 
         <plugin>


### PR DESCRIPTION
With these plugins, the MANIFEST.MF in the resulting jar should end up with version information. 
Using maven-jar-plugin, the version should be added to the manifest. 
Using buildnumber-maven-plugin, a datetime and revision part can be added to the version as well. This does require some extra plugin configuration in the project using this parent pom: can't enable that by default as it relies on SCM information.