### PR TITLE
AER-1740 Update spring boot version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,7 @@
     <maven-jar-plugin.version>3.3.0</maven-jar-plugin.version>
     <maven-surefire-plugin.version>3.0.0</maven-surefire-plugin.version>
     <openapi-generator-maven-plugin.version>6.5.0</openapi-generator-maven-plugin.version>
-    <spring-boot.version>3.0.6</spring-boot.version>
+    <spring-boot.version>3.1.0</spring-boot.version>
     <swagger-parser.version>2.1.13</swagger-parser.version>
     <validation-api.version>2.0.1.Final</validation-api.version>
     <versions-maven-plugin.version>2.15.0</versions-maven-plugin.version>


### PR DESCRIPTION
end_session_endpoint wasn't supported before spring-security 6.1.0, and we need to upgrade spring-boot to use that.
See https://github.com/spring-projects/spring-authorization-server/issues/266