### PR TITLE
Updating dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
   <description>Root parent pom providing common configuration for maven based projects within AERIUS</description>
 
   <properties>
-    <java.version>17</java.version>
+    <java.version>21</java.version>
     <maven.compiler.source>${java.version}</maven.compiler.source>
     <maven.compiler.target>${java.version}</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -41,19 +41,24 @@
     <sonar.host.url>https://sonarcloud.io</sonar.host.url>
 
     <aerius-tools.version>1.2.0</aerius-tools.version>
-    <buildnumber-maven-plugin.version>3.0.0</buildnumber-maven-plugin.version>
-    <dependency-check-maven.version>8.2.1</dependency-check-maven.version>
+    <buildnumber-maven-plugin.version>3.2.1</buildnumber-maven-plugin.version>
+    <build-helper-maven-plugin.version>3.6.0</build-helper-maven-plugin.version>
+    <dependency-check-maven.version>12.0.1</dependency-check-maven.version>
     <jackson-databind-nullable.version>0.2.6</jackson-databind-nullable.version>
-    <jacoco-maven-plugin.version>0.8.10</jacoco-maven-plugin.version>
-    <license-maven-plugin.version>4.2</license-maven-plugin.version>
-    <maven-enforcer-plugin.version>3.3.0</maven-enforcer-plugin.version>
-    <maven-jar-plugin.version>3.3.0</maven-jar-plugin.version>
-    <maven-surefire-plugin.version>3.0.0</maven-surefire-plugin.version>
-    <openapi-generator-maven-plugin.version>6.5.0</openapi-generator-maven-plugin.version>
-    <spring-boot.version>3.0.6</spring-boot.version>
-    <swagger-parser.version>2.1.13</swagger-parser.version>
-    <validation-api.version>2.0.1.Final</validation-api.version>
-    <versions-maven-plugin.version>2.15.0</versions-maven-plugin.version>
+    <jacoco-maven-plugin.version>0.8.12</jacoco-maven-plugin.version>
+    <license-maven-plugin.version>4.6</license-maven-plugin.version>
+    <maven-compiler-plugin.version>3.13.0</maven-compiler-plugin.version>
+    <maven-enforcer-plugin.version>3.5.0</maven-enforcer-plugin.version>
+    <maven-failsafe-plugin.version>3.5.2</maven-failsafe-plugin.version>
+    <maven-jar-plugin.version>3.4.2</maven-jar-plugin.version>
+    <maven-shade-plugin.version>3.6.0</maven-shade-plugin.version>
+    <maven-surefire-plugin.version>3.5.2</maven-surefire-plugin.version>
+    <maven-war-plugin.version>3.4.0</maven-war-plugin.version>
+    <openapi-generator-maven-plugin.version>7.11.0</openapi-generator-maven-plugin.version>
+    <spring-boot.version>3.4.2</spring-boot.version>
+    <swagger-parser.version>2.1.25</swagger-parser.version>
+    <jakarta-validation-api.version>3.1.0</jakarta-validation-api.version>
+    <versions-maven-plugin.version>2.18.0</versions-maven-plugin.version>
   </properties>
 
   <licenses>
@@ -114,9 +119,9 @@
         <version>${jackson-databind-nullable.version}</version>
       </dependency>
       <dependency>
-        <groupId>javax.validation</groupId>
-        <artifactId>validation-api</artifactId>
-        <version>${validation-api.version}</version>
+        <groupId>jakarta.validation</groupId>
+        <artifactId>jakarta.validation-api</artifactId>
+        <version>${jakarta-validation-api.version}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>
@@ -183,6 +188,29 @@
             </execution>
           </executions>
         </plugin>
+        
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-compiler-plugin</artifactId>
+          <version>${maven-compiler-plugin.version}</version>
+        </plugin>
+        
+        <plugin>
+          <groupId>org.codehaus.mojo</groupId>
+          <artifactId>build-helper-maven-plugin</artifactId>
+          <version>${build-helper-maven-plugin.version}</version>
+        </plugin>
+        
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-shade-plugin</artifactId>
+          <version>${maven-shade-plugin.version}</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-war-plugin</artifactId>
+          <version>${maven-war-plugin.version}</version>
+        </plugin>
 
         <plugin>
           <groupId>org.springframework.boot</groupId>
@@ -202,6 +230,12 @@
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-surefire-plugin</artifactId>
           <version>${maven-surefire-plugin.version}</version>
+        </plugin>
+        
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-failsafe-plugin</artifactId>
+          <version>${maven-failsafe-plugin.version}</version>
         </plugin>
 
         <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -193,6 +193,9 @@
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-compiler-plugin</artifactId>
           <version>${maven-compiler-plugin.version}</version>
+          <configuration>
+            <parameters>true</parameters>
+          </configuration>
         </plugin>
         
         <plugin>


### PR DESCRIPTION
Notable changes:
- Switch to java 21 from 17 (lets see if we can get this to work)
- javax.validation to jakarta.validation (should be about time)
- added a few specific versions for maven plugins in pluginManagement that were commonly used in depending projects
Other than that, switched to all the most current versions available.