### PR TITLE
Replacing swagger dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
     <maven-war-plugin.version>3.4.0</maven-war-plugin.version>
     <openapi-generator-maven-plugin.version>7.11.0</openapi-generator-maven-plugin.version>
     <spring-boot.version>3.4.2</spring-boot.version>
-    <swagger-parser.version>2.1.25</swagger-parser.version>
+    <swagger-annotations.version>2.2.28</swagger-annotations.version>
     <jakarta-validation-api.version>3.1.0</jakarta-validation-api.version>
     <versions-maven-plugin.version>2.18.0</versions-maven-plugin.version>
   </properties>
@@ -109,9 +109,9 @@
       </dependency>
 
       <dependency>
-        <groupId>io.swagger.parser.v3</groupId>
-        <artifactId>swagger-parser</artifactId>
-        <version>${swagger-parser.version}</version>
+        <groupId>io.swagger.core.v3</groupId>
+        <artifactId>swagger-annotations</artifactId>
+        <version>${swagger-annotations.version}</version>
       </dependency>
       <dependency>
         <groupId>org.openapitools</groupId>


### PR DESCRIPTION
The one used was adding all kinds of dependencies, like httpclient/commons-logging (which spring-boot didn't like, giving a warning on start). The new one contains all we really cared about: the annotation that is present in generated code.