### PR TITLE
Using new aerius-tools version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
     <sonar.organization>aerius</sonar.organization>
     <sonar.host.url>https://sonarcloud.io</sonar.host.url>
 
-    <aerius-tools.version>1.2.0</aerius-tools.version>
+    <aerius-tools.version>1.3.0-SNAPSHOT</aerius-tools.version>
     <buildnumber-maven-plugin.version>3.2.1</buildnumber-maven-plugin.version>
     <build-helper-maven-plugin.version>3.6.0</build-helper-maven-plugin.version>
     <dependency-check-maven.version>12.0.1</dependency-check-maven.version>


### PR DESCRIPTION
Eclipse configuration has been updated in that one, and spotless configuration uses some of those files.