### PR TITLE
Avoid mockito warning by implementing javaagent method

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,6 +48,7 @@
     <maven-clean-plugin.version>3.4.0</maven-clean-plugin.version>
     <maven-compiler-plugin.version>3.13.0</maven-compiler-plugin.version>
     <maven-deploy-plugin.version>3.1.3</maven-deploy-plugin.version>
+    <maven-dependency-plugin.version>3.8.1</maven-dependency-plugin.version>
     <maven-enforcer-plugin.version>3.5.0</maven-enforcer-plugin.version>
     <maven-failsafe-plugin.version>3.5.2</maven-failsafe-plugin.version>
     <maven-install-plugin.version>3.1.3</maven-install-plugin.version>
@@ -66,6 +67,9 @@
     <!-- Match flyway version in spring boot -->
     <flyway-maven-plugin.version>10.20.1</flyway-maven-plugin.version>
     <jooq-codegen-maven.version>3.19.18</jooq-codegen-maven.version>
+
+    <!-- Required for mockito as java-agent -->
+    <argLine/>
   </properties>
 
   <licenses>
@@ -264,6 +268,9 @@
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-surefire-plugin</artifactId>
           <version>${maven-surefire-plugin.version}</version>
+          <configuration>
+            <argLine>@{argLine} -javaagent:${org.mockito:mockito-core:jar}</argLine>
+          </configuration>
         </plugin>
 
         <plugin>
@@ -428,6 +435,23 @@
     </pluginManagement>
 
     <plugins>
+      <!--
+        Configure dependency plugin to add a property to the artifact file for each dependency.
+        Required to use mockito as a java agent.
+      -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-dependency-plugin</artifactId>
+        <version>${maven-dependency-plugin.version}</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>properties</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+
       <plugin>
         <groupId>com.mycila</groupId>
         <artifactId>license-maven-plugin</artifactId>


### PR DESCRIPTION
Based on the following warning that could be seen in maven runs: Mockito is currently self-attaching to enable the inline-mock-maker. This will no longer work in future releases of the JDK. Please add Mockito as an agent to your build what is described in Mockito's documentation: https://javadoc.io/doc/org.mockito/mockito-core/latest/org/mockito/Mockito.html#0.3