### PR TITLE
Updating owasp plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,7 @@
     <aerius-tools.version>1.3.0-SNAPSHOT</aerius-tools.version>
     <buildnumber-maven-plugin.version>3.2.1</buildnumber-maven-plugin.version>
     <build-helper-maven-plugin.version>3.6.0</build-helper-maven-plugin.version>
-    <dependency-check-maven.version>12.0.1</dependency-check-maven.version>
+    <dependency-check-maven.version>12.1.0</dependency-check-maven.version>
     <jackson-databind-nullable.version>0.2.6</jackson-databind-nullable.version>
     <jacoco-maven-plugin.version>0.8.12</jacoco-maven-plugin.version>
     <license-maven-plugin.version>4.6</license-maven-plugin.version>


### PR DESCRIPTION
There's a new value in NVD data (which shouldn't be there anyway ccording to specs apparantly) that couldn't be parsed. This version fixes that issue.