### PR TITLE
Add org.gwtproject.version (GWT 2.13.1) for aerius GWT frontends

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,6 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
-    <!-- GWT toolchain, shared by aerius GWT frontends -->
     <org.gwtproject.version>2.13.1</org.gwtproject.version>
     <gwt.java.version>17</gwt.java.version>
     <gwt-maven-plugin.version>1.1.0</gwt-maven-plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -33,6 +33,9 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
+    <!-- GWT compiler version, shared by aerius GWT frontends (gwt-client-common, calculator) -->
+    <org.gwtproject.version>2.13.1</org.gwtproject.version>
+
     <!-- Expected to be defined in projects using this root pom: sonar.projectKey -->
     <sonar.moduleKey>${project.artifactId}</sonar.moduleKey>
     <sonar.organization>aerius</sonar.organization>

--- a/pom.xml
+++ b/pom.xml
@@ -33,8 +33,10 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
-    <!-- GWT compiler version, shared by aerius GWT frontends (gwt-client-common, calculator) -->
+    <!-- GWT toolchain, shared by aerius GWT frontends (gwt-client-common, calculator) -->
     <org.gwtproject.version>2.13.1</org.gwtproject.version>
+    <gwt.java.version>17</gwt.java.version>
+    <gwt-maven-plugin.version>1.1.0</gwt-maven-plugin.version>
 
     <!-- Expected to be defined in projects using this root pom: sonar.projectKey -->
     <sonar.moduleKey>${project.artifactId}</sonar.moduleKey>

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
-    <!-- GWT toolchain, shared by aerius GWT frontends (gwt-client-common, calculator) -->
+    <!-- GWT toolchain, shared by aerius GWT frontends -->
     <org.gwtproject.version>2.13.1</org.gwtproject.version>
     <gwt.java.version>17</gwt.java.version>
     <gwt-maven-plugin.version>1.1.0</gwt-maven-plugin.version>


### PR DESCRIPTION
Owns the GWT compiler version here so it is inherited by aerius GWT frontends (gwt-client-common, calculator) instead of duplicated per-repo, where the copies can silently drift.

Set to 2.13.1 (latest). Harmless to non-GWT consumers - just an unused property.