### PR TITLE
Add exec-maven-plugin to pluginManagement

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,6 +46,7 @@
     <buildnumber-maven-plugin.version>3.3.0</buildnumber-maven-plugin.version>
     <build-helper-maven-plugin.version>3.6.1</build-helper-maven-plugin.version>
     <dependency-check-maven.version>12.2.2</dependency-check-maven.version>
+    <exec-maven-plugin.version>3.6.3</exec-maven-plugin.version>
     <jackson-databind-nullable.version>0.2.10</jackson-databind-nullable.version>
     <jacoco-maven-plugin.version>0.8.15</jacoco-maven-plugin.version>
     <license-maven-plugin.version>5.0.0</license-maven-plugin.version>
@@ -267,6 +268,12 @@
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-war-plugin</artifactId>
           <version>${maven-war-plugin.version}</version>
+        </plugin>
+
+        <plugin>
+          <groupId>org.codehaus.mojo</groupId>
+          <artifactId>exec-maven-plugin</artifactId>
+          <version>${exec-maven-plugin.version}</version>
         </plugin>
 
         <plugin>


### PR DESCRIPTION
This is a plugin that we use in a couple of projects, so might as well centralize keeping the version up to date.