### PR TITLE
AER-4118 Copyright normalization

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
     <sonar.organization>aerius</sonar.organization>
     <sonar.host.url>https://sonarcloud.io</sonar.host.url>
 
-    <aerius-tools.version>1.3.0</aerius-tools.version>
+    <aerius-tools.version>1.4.0-SNAPSHOT</aerius-tools.version>
     <buildnumber-maven-plugin.version>3.3.0</buildnumber-maven-plugin.version>
     <build-helper-maven-plugin.version>3.6.1</build-helper-maven-plugin.version>
     <dependency-check-maven.version>12.2.2</dependency-check-maven.version>

--- a/pom.xml
+++ b/pom.xml
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright the State of the Netherlands
+    Copyright (c) Contributors to the project
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU Affero General Public License as published by
@@ -88,6 +88,17 @@
       <url>http://www.gnu.org/licenses/agpl-3.0.txt</url>
     </license>
   </licenses>
+
+  <contributors>
+    <contributor>
+      <organization>Ministry of Agriculture, Fisheries, Food Security and Nature</organization>
+      <organizationUrl>https://www.government.nl/ministries/ministry-of-agriculture-fisheries-food-security-and-nature</organizationUrl>
+    </contributor>
+    <contributor>
+      <organization>Government of the United Kingdom</organization>
+      <organizationUrl>https://www.gov.uk</organizationUrl>
+    </contributor>
+  </contributors>
 
   <distributionManagement>
     <repository>


### PR DESCRIPTION
- Update contributors in pom.xml
- Update copyright header in the pom.xml
- Update aerius-tools version to the latest one, in order to use the latest copyright header from tools

Requires https://github.com/aerius/tools/pull/31